### PR TITLE
Fix PHP timezone warning at runtime

### DIFF
--- a/gh-changelog.php
+++ b/gh-changelog.php
@@ -7,8 +7,8 @@ ini_set( 'date.timezone', 'UTC' );
 /* 
 * YOU MUST CHANGE THESE VARIABLES 
 */
-$gh_user = 'snipe';
-$gh_repo = 'snipe-it';
+$gh_user = 'your-user';
+$gh_repo = 'your-repo';
 $file = 'CHANGELOG.md';
 $string = 'fix|resolve|closes|closed|#changelog';
 $omit = 'fuck|another';

--- a/gh-changelog.php
+++ b/gh-changelog.php
@@ -1,11 +1,14 @@
 <?php
 #!/usr/bin/php -q
 
+/* PHP requires defined timezone; GitHub uses UTC */
+ini_set( 'date.timezone', 'UTC' );
+
 /* 
 * YOU MUST CHANGE THESE VARIABLES 
 */
-$gh_user = 'your-user';
-$gh_repo = 'your-repo';
+$gh_user = 'snipe';
+$gh_repo = 'snipe-it';
 $file = 'CHANGELOG.md';
 $string = 'fix|resolve|closes|closed|#changelog';
 $omit = 'fuck|another';


### PR DESCRIPTION
PHP 5 warns about the timezone not being set at runtime. The ini_set addresses this with the timezone that's present in the data being returned from the GitHub API.
